### PR TITLE
Arreglar importador de XLSX

### DIFF
--- a/public/node/lib/misc.js
+++ b/public/node/lib/misc.js
@@ -42,12 +42,17 @@ function generateSQL(data) {
 
   for (let i = 0; i < data.length; i++) {
     let dataRow = data[i];
-    let stringRow = Object.keys(xlsxHeaders).map((x) => `"${dataRow[xlsxHeaders[x]] || ''}"`).join(", ");
+    let stringRow = Object.keys(xlsxHeaders).map((x) => `"${cleanValue(dataRow[xlsxHeaders[x]])}"`).join(", ");
     insertValues.push(`(${stringRow}, "Sin comenzar", ${createdAt})`);
   }
 
   let fields = Object.keys(xlsxHeaders).map((x) => x).join(", ");
   return `INSERT INTO cartas(${fields}, "estado", "fecha") VALUES ${insertValues.join(", ")};`;
+}
+
+function cleanValue(val) {
+  if (typeof val != "string") return val;
+  return (val || '').replace(/"/g, "").replace(/'/g, "");
 }
 
 module.exports = {


### PR DESCRIPTION
El error al importar los archivos se daba porque habían cadenas en el archivo que llevaban comillas (", ') y había que removerlas porque sino el SQL que se generaba daba error.